### PR TITLE
Perform Docker image build on Dockercloud (Docker Hub).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
   - "3.5"
   - "3.6"
 cache: pip
-services:
-  - docker
 before_install:
 # Update the package repository
 - sudo apt-get -qq update
@@ -39,6 +37,3 @@ install:
 script:
 - pytest -k 'not boundaries'
 - ./terraform validate terraform-infra
-- docker build -t doughgle/cryptocracy .
-- echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-- docker push doughgle/cryptocracy


### PR DESCRIPTION
Remove docker build (and Dockercloud creds) from Travis.